### PR TITLE
Added custom url to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,25 @@ export class MyService {
 
 ### Metric endpoint
 
-At the moment, no way to configure the `/metrics` endpoint path.
+The default metrics endpoint is `/metrics` this can be changed with the customUrl option
 
-PS: If you have a global prefix, the path will be `{globalPrefix}/metrics` for
+```ts
+@Module({
+  imports: [
+    PromModule.forRoot({
+      defaultLabels: {
+        app: 'my_app',
+      },
+      customUrl: 'custom/uri',
+    }),
+  ],
+})
+export class MyModule
+```
+
+Now your metrics can be found at `/custom/uri`.
+
+> PS: If you have a global prefix, the path will be `{globalPrefix}/metrics` for
 the moment.
 
 ## API

--- a/lib/interfaces/prom-options.interface.ts
+++ b/lib/interfaces/prom-options.interface.ts
@@ -25,4 +25,6 @@ export interface PromModuleOptions {
   defaultLabels?: {
     [key: string]: any,
   };
+
+  customUrl?: string;
 }

--- a/lib/prom.controller.ts
+++ b/lib/prom.controller.ts
@@ -1,11 +1,17 @@
 import { Controller, Get, Res } from "@nestjs/common";
 import * as client from 'prom-client';
+import { PATH_METADATA } from '@nestjs/common/constants';
 
-@Controller('metrics')
+@Controller()
 export class PromController {
   @Get()
   index(@Res() res) {
     res.set('Content-Type', client.register.contentType);
     res.end(client.register.metrics());
+  }
+
+  public static forRoot(path: string) {
+    Reflect.defineMetadata(PATH_METADATA, path, PromController);
+    return PromController;
   }
 }

--- a/lib/prom.module.ts
+++ b/lib/prom.module.ts
@@ -30,7 +30,7 @@ export class PromModule {
 
     // default push default controller
     if (withDefaultController !== false) {
-      moduleForRoot.controllers = [...moduleForRoot.controllers, PromController];
+      moduleForRoot.controllers = [...moduleForRoot.controllers, PromController.forRoot(options.customUrl || 'metrics')];
     }
 
     // if want to use the http counter


### PR DESCRIPTION
Sorry for unsolicited PR. I saw your TODO list and couldn't help myself. 

I've added a static method called forRoot to the controller so that we can define the metadata to that of in the options. Let me know what you think. I haven't tested it yet but I've used this method before :) 

### TODO 
- [x] add to readme 
- [ ] test