### PR TITLE
Feature/prom method counter generic type

### DIFF
--- a/lib/common/prom.decorators.ts
+++ b/lib/common/prom.decorators.ts
@@ -19,7 +19,7 @@ export const PromMethodCounter = () => {
         const methodFunc = descriptor.value;
 
         if (!methodFunc) {
-            throw new Error('Decorator was invoked not under the method');
+            throw new Error('Decorator was invoked not for the method');
         }
 
         descriptor.value = function (...args: any[]) {

--- a/lib/common/prom.decorators.ts
+++ b/lib/common/prom.decorators.ts
@@ -17,7 +17,6 @@ export const PromMethodCounter = () => {
             help: `app_${className}#${propertyKey.toString()} called total`,
         });
         const methodFunc = descriptor.value;
-
         descriptor.value = function (...args: any[]) {
             counterMetric.inc(1);
             return methodFunc.apply(this, args);

--- a/lib/common/prom.decorators.ts
+++ b/lib/common/prom.decorators.ts
@@ -1,6 +1,5 @@
 import { Inject } from '@nestjs/common';
 import { getMetricToken, findOrCreateCounter } from './prom.utils';
-import * as client from 'prom-client';
 
 export const InjectCounterMetric = (name: string) => Inject(getMetricToken(`Counter`, name));
 export const InjectGaugeMetric = (name: string) => Inject(getMetricToken(`Gauge`, name));
@@ -9,8 +8,6 @@ export const InjectSummaryMetric = (name: string) => Inject(getMetricToken(`Summ
 
 /**
  * Create and increment a counter when the method is called
- * 
- * @param param0 
  */
 export const PromMethodCounter = () => {
     return (target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<Function>) => {
@@ -29,8 +26,8 @@ export const PromMethodCounter = () => {
 
 /**
  * Create and increment a counter when a new instance is created
- * 
- * @param ctor 
+ *
+ * @param ctor
  */
 export const PromInstanceCounter = <T extends { new(...args: any[]): {} }>(ctor: T) => {
     const counterMetric = findOrCreateCounter({

--- a/lib/common/prom.decorators.ts
+++ b/lib/common/prom.decorators.ts
@@ -9,8 +9,8 @@ export const InjectSummaryMetric = (name: string) => Inject(getMetricToken(`Summ
 /**
  * Create and increment a counter when the method is called
  */
-export const PromMethodCounter = <T extends any> () => {
-    return (target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<(...args: any[]) => T>) => {
+export const PromMethodCounter = () => {
+    return (target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<(...args: any[]) => any>) => {
         const className = target.constructor.name;
         const counterMetric = findOrCreateCounter({
             name: `app_${className}_${propertyKey.toString()}_calls_total`,
@@ -22,30 +22,7 @@ export const PromMethodCounter = <T extends any> () => {
             throw new Error('Decorator was invoked not under the method');
         }
 
-        descriptor.value = function (...args: any[]): T {
-            counterMetric.inc(1);
-            return methodFunc.apply(this, args);
-        };
-    };
-}
-
-/**
- * Create and increment a counter when the async method is called
- */
-export const PromAsyncMethodCounter = <T extends any> () => {
-    return (target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<(...args: any[]) => Promise<T>>) => {
-        const className = target.constructor.name;
-        const counterMetric = findOrCreateCounter({
-            name: `app_${className}_${propertyKey.toString()}_calls_total`,
-            help: `app_${className}#${propertyKey.toString()} called total`,
-        });
-        const methodFunc = descriptor.value;
-
-        if (!methodFunc) {
-            throw new Error('Decorator was invoked not under the method');
-        }
-
-        descriptor.value = async function (...args: any[]): Promise<T> {
+        descriptor.value = function (...args: any[]) {
             counterMetric.inc(1);
             return methodFunc.apply(this, args);
         };

--- a/lib/common/prom.decorators.ts
+++ b/lib/common/prom.decorators.ts
@@ -18,10 +18,6 @@ export const PromMethodCounter = () => {
         });
         const methodFunc = descriptor.value;
 
-        if (!methodFunc) {
-            throw new Error('Decorator was invoked not for the method');
-        }
-
         descriptor.value = function (...args: any[]) {
             counterMetric.inc(1);
             return methodFunc.apply(this, args);


### PR DESCRIPTION
So, in TypeScript's strict mode `strict: "true"` `Function` more general type than a regular method. In case, when you use `Function` type it means the function will be used not only as a regular callable method but also as a constructable method like `new Function()`. But in case when you use arrow function `() => {}` it means the function will be used ONLY as a regular callable method (we assume that every class method invoked ONLY as a callable method and cannot be invoked as a constructor). So, problem with typings of `@PromMethodCounter` is that you invoked that decorator under the ONLY callable method, but decorator returns `Function` type that can be also a constructable method. It is forbidden to make a narrow type wider. 