### PR TITLE
set buckets as optional in histogram

### DIFF
--- a/lib/common/prom.utils.ts
+++ b/lib/common/prom.utils.ts
@@ -76,12 +76,15 @@ export function findOrCreateMetric({
       if (metric && metric instanceof client.Histogram) {
         return metric;
       }
-      return new client.Histogram({
+      const histogramConfig = {
         name: name,
         help: help || `${name} ${type}`,
         labelNames,
-        buckets,
-      });
+      };
+      if (buckets) {
+        histogramConfig['buckets'] = buckets;
+      }
+      return new client.Histogram(histogramConfig);
     case "Summary":
       if (metric && metric instanceof client.Summary) {
         return metric;


### PR DESCRIPTION
because it's breaking when I don't supply buckets. I want to use default values (in prom-client) instead.